### PR TITLE
Make "Saved" text look less like a button

### DIFF
--- a/client/react/app/App.less
+++ b/client/react/app/App.less
@@ -119,16 +119,6 @@ a {
   }
 }
 
-.btn-saving {
-  min-width: 132px;
-  text-align: left;
-
-  &:hover {
-    background: @light-gray-3 !important; // TODO: not ideal
-    cursor: default;
-  }
-}
-
 .btn-default {
   background: @light-gray-3;
   border: 1px solid @light-gray-3;
@@ -215,6 +205,18 @@ a {
       color: @white;
       background-color: @bright-blue;
     }
+  }
+}
+
+.btn-saving {
+  min-width: 132px;
+  text-align: left;
+  background: transparent;
+  border: none;
+
+  &:hover {
+    background: transparent;
+    cursor: default;
   }
 }
 


### PR DESCRIPTION
Fixes #125 

<img width="1083" alt="screen shot 2018-04-22 at 1 14 41 pm" src="https://user-images.githubusercontent.com/5264279/39099388-53c0695a-462f-11e8-8ea2-7a35475c924a.png">
