### PR TITLE
Create progress bar for depression questionnaire

### DIFF
--- a/client/react/app/components/checklist/Checklist.less
+++ b/client/react/app/components/checklist/Checklist.less
@@ -1,5 +1,6 @@
 @bright-blue: #33A2CC;
 @border-gray: #d3d3d3;
+@gray: #979797;
 @font-handwritten: 'Covered By Your Grace', cursive;
 
 // TODO: DRY this up (see .checklist-v2)
@@ -88,6 +89,30 @@
     margin-bottom: 40px;
     overflow: hidden;
     position: relative;
+  }
+
+  .checklist-progress-container {
+    padding-bottom: 24px;
+
+    .checklist-category {
+      color: @gray;
+      margin-bottom: 8px;
+    }
+
+    .checklist-progress-label {
+      color: @gray;
+      font-size: 14px;
+    }
+
+    .checklist-progress-bar {
+      height: 8px;
+      margin-top: 16px;
+    }
+
+    .checklist-progress-segment {
+      height: 100%;
+      position: relative;
+    }
   }
 
   .checklist-header {

--- a/client/react/app/components/checklist/ChecklistFlow.tsx
+++ b/client/react/app/components/checklist/ChecklistFlow.tsx
@@ -21,6 +21,10 @@ const ChecklistProgressBar = ({
   currentIndex,
   questions = []
 }: ChecklistProgressBarProps) => {
+  if (!questions || !questions.length) {
+    return null;
+  }
+
   const currentQuestion = questions[currentIndex];
   const { category } = currentQuestion;
 

--- a/client/react/app/components/checklist/ChecklistFlow.tsx
+++ b/client/react/app/components/checklist/ChecklistFlow.tsx
@@ -8,6 +8,55 @@ import {
 } from '../../helpers/checklist';
 import './Checklist.less';
 
+// TODO: DRY up in other places
+const INACTIVE_COLOR = '#D2D2D2';
+const ACTIVE_COLORS = ['#B8DBE9', '#8BC9E1', '#72BFDB', '#4FAED1', '#33A2CC'];
+
+interface ChecklistProgressBarProps {
+  currentIndex: number;
+  questions: IQuestion[];
+}
+
+const ChecklistProgressBar = ({
+  currentIndex,
+  questions = []
+}: ChecklistProgressBarProps) => {
+  const currentQuestion = questions[currentIndex];
+  const { category } = currentQuestion;
+
+  return (
+    <div className='checklist-progress-container text-center'>
+      <div className='checklist-category'>{category}</div>
+      <div className='checklist-progress-label'>
+        Question <span className='text-blue'>{currentIndex + 1}</span> / 25
+      </div>
+
+      <div className='checklist-progress-bar clearfix'>
+        {
+          questions.map((question, key) => {
+            const { score } = question;
+            const isActive = (currentIndex === key);
+            const style = {
+              width: '4%',
+              borderBottom: isActive ? '1px solid #979797' : 'none',
+              backgroundColor: (isNumber(score) && !!ACTIVE_COLORS[score])
+                ? ACTIVE_COLORS[score]
+                : INACTIVE_COLOR
+            };
+
+            return (
+              <div key={key}
+                style={style}
+                className='checklist-progress-segment pull-left'>
+              </div>
+            );
+          })
+        }
+      </div>
+    </div>
+  );
+};
+
 interface ChecklistProps {
   checklist: IChecklist;
   date: moment.Moment;
@@ -140,10 +189,15 @@ class ChecklistFlow extends React.Component<ChecklistProps, ChecklistState> {
           </div>
         </div>
 
+        <ChecklistProgressBar
+          currentIndex={currentIndex}
+          questions={questions} />
+
         <div className='checklist-container clearfix'>
           {
             questions.map((question, key) => {
               const offset = (key - currentIndex) * 60;
+
               return (
                 <ChecklistFlowQuestion
                   key={key}


### PR DESCRIPTION
Fixes #152 

Adds progress bar to show answers to previous questions, as well as let the user know how many questions are left.

<img width="1182" alt="screen shot 2018-05-06 at 1 18 24 pm" src="https://user-images.githubusercontent.com/5264279/39677513-da452e8c-5130-11e8-8f50-b14022f66cc7.png">
